### PR TITLE
Improve UI for inputs on mobile

### DIFF
--- a/src/ibc/components/Deposit.tsx
+++ b/src/ibc/components/Deposit.tsx
@@ -1308,7 +1308,9 @@ function Deposit() {
             classNamePrefix="react-select-wrap"
           />
           <input
-            type="text"
+            type="number"
+            min="0"
+            step="0.000001"
             value={amountToTransfer}
             onChange={handleInputChange}
             className={

--- a/src/wrap/Wrap.tsx
+++ b/src/wrap/Wrap.tsx
@@ -849,7 +849,9 @@ export function Wrap() {
                 <input
                   value={amountString}
                   onChange={handleInputChange}
-                  type="text"
+                  type="number"
+                  min="0"
+                  step="0.000001"
                   className={
                     "text-right focus:z-10 block flex-1 min-w-0 w-full bg-neutral-100 dark:bg-neutral-900 text-black dark:text-white px-4 rounded-r-lg disabled:placeholder-neutral-300 dark:disabled:placeholder-neutral-700 transition-colors font-medium focus:outline-0 focus:ring-2 ring-sky-500/40" +
                     (!isValidAmount && isValidationActive
@@ -913,7 +915,9 @@ export function Wrap() {
                 <input
                   value={amountString}
                   onChange={handleInputChange}
-                  type="text"
+                  type="number"
+                  min="0"
+                  step="0.000001"
                   className={
                     "text-right focus:z-10 block flex-1 min-w-0 w-full bg-neutral-100 dark:bg-neutral-900 text-black dark:text-white px-4 rounded-r-lg disabled:placeholder-neutral-300 dark:disabled:placeholder-neutral-700 transition-colors font-medium focus:outline-0 focus:ring-2 ring-sky-500/40"
                   }


### PR DESCRIPTION
This PR changes several `<input>` `type` attributes to use `number` instead of `text` on the IBC deposit and Wrap pages for better experience on mobile. The `step` attribute provides a minimum step amount for users with hard keyboards who may try to use up/down arrows to adjust amounts.

### Before | After:
<img src="https://github.com/scrtlabs/dash.scrt.network/assets/1456400/620b3436-15b3-4bd9-a195-bb05b7fbf12b" width="300" />&nbsp;<img src="https://github.com/scrtlabs/dash.scrt.network/assets/1456400/732dee7c-c187-4fc9-ada8-3506ddd61957" width="300" />
