### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/scrtlabs/dash.scrt.network/security/code-scanning/1](https://github.com/scrtlabs/dash.scrt.network/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only checks out the repository and builds a Docker image, it does not require write permissions. The minimal required permission is `contents: read`. This change ensures that the workflow explicitly limits the permissions of the `GITHUB_TOKEN` to the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
